### PR TITLE
wrap filter query in backticks

### DIFF
--- a/src/components/Sidebar/FacetSelect/FacetSelect.css
+++ b/src/components/Sidebar/FacetSelect/FacetSelect.css
@@ -39,6 +39,7 @@
     padding-left: 0.125rem;
     padding-right: 0.125rem;
     border-radius: 0.25rem;
+    user-select: none;
 }
 
 .fs_switchbutton:hover {

--- a/src/components/Sidebar/FacetSelect/FacetSelect.tsx
+++ b/src/components/Sidebar/FacetSelect/FacetSelect.tsx
@@ -68,7 +68,7 @@ export function FacetSelect(
     };
 
     const toggleOp = () => {
-        const newOp = filterOp === 'and' ? 'and' : 'or';
+        const newOp = filterOp === 'and' ? 'or' : 'and';
         setFilter(d => {
             d.op = newOp;
         });
@@ -88,7 +88,7 @@ export function FacetSelect(
                                 class="fs_switchbutton"
                                 onClick={toggleOp}
                             >
-                                {filterOp === 'or' ? 'or' : 'and'}
+                                {filterOp}
                             </button>
                         </div>
                     )
@@ -107,10 +107,6 @@ export function FacetSelect(
             <ul class="fs_list">
                 {
                     facet && sortBy(facet.counts, sortByFunc).map(f => {
-                        { /* temp hack: https://github.com/typesense/typesense/issues/832 */ }
-                        if (facet.field_name == 'tags' && f.value == 'as you can tell I\'m a master at writing relevant tags') {
-                            return null;
-                        }
                         return (
                             <li class="fs_item" key={f.value}>
                                 <label class="fs_control">

--- a/src/store/filterByString.ts
+++ b/src/store/filterByString.ts
@@ -17,13 +17,13 @@ export const filterByStringAtom = atom(get => {
                 if (filter.values.size === 0) {
                     return prev;
                 }
+                // backticks denote literal strings in Typesense
+                const values = [...filter.values].map(v => `\`${v}\``);
                 if (filter.op === 'and') {
-                    const values = [...filter.values];
                     const nexts = values.map(v => `${filter.name}:=${v}`);
                     return [...prev, ...nexts];    
                 }
                 if (filter.op === 'or') {
-                    const values = [...filter.values];
                     const next = `${filter.name}:=[${values.join(',')}]`;
                     return [...prev, next];
                 }


### PR DESCRIPTION
fixes #59 

The artist had a parenthesis in the name, so Typesense was trying to parse it as an order of operations. Wrapping the literal in backticks fixes this https://typesense.org/docs/0.24.0/api/search.html#query-parameters