### PR TITLE
wrap string facets in backticks but not number facets

### DIFF
--- a/src/components/Sidebar/FacetSelect/FacetSelect.tsx
+++ b/src/components/Sidebar/FacetSelect/FacetSelect.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from 'preact/hooks';
 import './FacetSelect.css';
 import sortBy from 'just-sort-by';
 import { useAtom } from 'jotai/react';
-import { castDraft, castImmutable } from 'immer';
+import { castDraft } from 'immer';
 
 type SortableValue = string | number;
 

--- a/src/components/Sidebar/FacetSelect/FacetSelect.tsx
+++ b/src/components/Sidebar/FacetSelect/FacetSelect.tsx
@@ -9,28 +9,60 @@ import { useMemo, useState } from 'preact/hooks';
 import './FacetSelect.css';
 import sortBy from 'just-sort-by';
 import { useAtom } from 'jotai/react';
+import { castDraft, castImmutable } from 'immer';
 
 type SortableValue = string | number;
 
-type FacetSelectProps = {
-    atom: ImmerAtom<SetFilter>;
+/**
+ * Configuration type for FacetSelect.
+ */
+type FacetSelectProps<T extends string | number> = {
+    /**
+     * The atom that's being controlled by this FacetSelect.
+     */
+    atom: ImmerAtom<SetFilter<T>>;
+    /**
+     * Name that appears above the selector.
+     */
     humanName: string;
+    /**
+     * Whether to show the ability to switch "and"/"or" modes.
+     * This isn't very functional at the moment.
+     */
     showSwitch?: boolean;
+    /**
+     * Whether to show the search bar at the top of the filter.
+     */
     showFilter?: boolean;
-    valueTransformFunc?: (s: string) => string;
+    /**
+     * An optional function that can be provided to change the displayed values
+     * of the facet. e.g. Difficulty's values are numbers from 0-3, but we want to show the words
+     * "Easy", "Medium", etc.
+     */
+    valueDisplayFunc?: (s: T) => string;
+    /**
+     * The facets that come from Typesense are always strings. If T is not string,
+     * a function must be provided to turn the values back.
+     */
+    stringToFacetFunc: (s: string) => T;
+    /**
+     * An optional function to sort the facet set. By default it sorts by count, descending.
+     */
     sortByFunc?: (s: SearchResponseFacetCountSchema<Level>['counts'][number]) => SortableValue;
 } & WithClass;
 
-export function FacetSelect(
+
+export function FacetSelect<T extends string | number>(
     {
         'class': _class,
         atom,
         humanName,
         'showSwitch': _showSwitch = true,
         showFilter = true,
-        valueTransformFunc = s => `${s}`,
+        valueDisplayFunc = s => `${s}`,
+        stringToFacetFunc,
         sortByFunc = s => s.count * -1
-    }: FacetSelectProps) {
+    }: FacetSelectProps<T>) {
     const [filter, setFilter] = useAtom(atom);
 
     const facetName = filter.name;
@@ -55,14 +87,16 @@ export function FacetSelect(
     const total = facet?.stats.total_values || 0;
 
     const toggle = (value: string) => {
-        const currentlySelected = selected.has(value);
+        const setValue = stringToFacetFunc(value);
+        const currentlySelected = selected.has(setValue);
+        const castValue = castDraft(setValue); // = setValue
         if (currentlySelected) {
             setFilter(d => {
-                d.values.delete(value);
+                d.values.delete(castValue);
             });
         } else {
             setFilter(d => {
-                d.values.add(value);
+                d.values.add(castValue);
             });
         }
     };
@@ -107,20 +141,16 @@ export function FacetSelect(
             <ul class="fs_list">
                 {
                     facet && sortBy(facet.counts, sortByFunc).map(f => {
-                        { /* temp hack: https://github.com/typesense/typesense/issues/832 */ }
-                        if (facet.field_name == 'tags' && f.value == 'as you can tell I\'m a master at writing relevant tags') {
-                            return null;
-                        }
                         return (
                             <li class="fs_item" key={f.value}>
                                 <label class="fs_control">
                                     <input
                                         class="fs_checkbox"
                                         type="checkbox"
-                                        checked={selected.has(f.value)}
+                                        checked={selected.has(stringToFacetFunc(f.value))}
                                         onClick={() => toggle(f.value)}
                                     />
-                                    {valueTransformFunc(f.value)}
+                                    {valueDisplayFunc(stringToFacetFunc(f.value))}
                                 </label>
                                 <span class="fs_count">({f.count})</span>
                             </li>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { approvalFilterAtom, artistFilterAtom, authorsFilterAtom, difficultyFilt
 import { FacetSelect } from '@orchard/components/Sidebar/FacetSelect';
 import { SimplePeerReviewSelect } from '@orchard/components/Sidebar/SimplePeerReviewSelect';
 import { SlidySelect } from '@orchard/components/Sidebar/SlidySelect';
+import { identity } from '@orchard/utils/grabbag';
 
 type SidebarProps = WithClass;
 export function Sidebar({ 'class': _class }: SidebarProps) {
@@ -14,7 +15,7 @@ export function Sidebar({ 'class': _class }: SidebarProps) {
 
     const facets = resp?.data.facet_counts;
 
-    const difficultyName = (v: string) => ['Easy', 'Medium', 'Tough', 'Very Tough'][parseInt(v)];
+    const difficultyName = (v: number) => ['Easy', 'Medium', 'Tough', 'Very Tough'][v];
 
     const [advancedFilters] = usePreference('show advanced filters');
 
@@ -23,14 +24,15 @@ export function Sidebar({ 'class': _class }: SidebarProps) {
             {
                 facets && (
                     <>
-                        <FacetSelect class="sb_facet" atom={tagsFilterAtom} humanName="Tags" />
-                        <FacetSelect class="sb_facet" atom={authorsFilterAtom} humanName="Authors" />
-                        <FacetSelect class="sb_facet" atom={artistFilterAtom} humanName="Artist" />
+                        <FacetSelect class="sb_facet" atom={tagsFilterAtom} stringToFacetFunc={identity} humanName="Tags" />
+                        <FacetSelect class="sb_facet" atom={authorsFilterAtom} stringToFacetFunc={identity} humanName="Authors" />
+                        <FacetSelect class="sb_facet" atom={artistFilterAtom} stringToFacetFunc={identity} humanName="Artist" />
                         <FacetSelect
                             class="sb_facet"
                             atom={difficultyFilterAtom}
                             humanName="Difficulty"
-                            valueTransformFunc={difficultyName}
+                            valueDisplayFunc={difficultyName}
+                            stringToFacetFunc={parseInt}
                             sortByFunc={s => s.value}
                             showSwitch={false}
                             showFilter={false}

--- a/src/store/filterByString.ts
+++ b/src/store/filterByString.ts
@@ -17,13 +17,12 @@ export const filterByStringAtom = atom(get => {
                 if (filter.values.size === 0) {
                     return prev;
                 }
+                const values = [...filter.values].map(v => typeof v === 'string' ? `\`${v}\`` : v);
                 if (filter.op === 'and') {
-                    const values = [...filter.values];
                     const nexts = values.map(v => `${filter.name}:=${v}`);
                     return [...prev, ...nexts];    
                 }
                 if (filter.op === 'or') {
-                    const values = [...filter.values];
                     const next = `${filter.name}:=[${values.join(',')}]`;
                     return [...prev, next];
                 }

--- a/src/store/filters.ts
+++ b/src/store/filters.ts
@@ -16,10 +16,10 @@ export type BaseFilter = {
     active: boolean;
 };
 
-export type SetFilter = BaseFilter & {
+export type SetFilter<T extends string | number> = BaseFilter & {
     type: 'set';
     op: 'and' | 'or';  // and: all the values must be in the set. or: only one value has to be in the set.
-    values: Set<string | number>;
+    values: Set<T>;
 };
 
 export type RangeFilter = BaseFilter & {
@@ -46,36 +46,36 @@ const filterAtom = <T>(initialValue: T) => {
     return withImmer(innerAtom);
 };
 
-export const difficultyFilterAtom = filterAtom<SetFilter>({
+export const difficultyFilterAtom = filterAtom<SetFilter<number>>({
     name: 'difficulty',
     type: 'set',
     op: 'or',
     active: true,
-    values: new Set<number>([])
+    values: new Set([])
 });
 
-export const authorsFilterAtom = filterAtom<SetFilter>({
+export const authorsFilterAtom = filterAtom<SetFilter<string>>({
     name: 'authors',
     type: 'set',
     op: 'and',
     active: true,
-    values: new Set<string>([])
+    values: new Set([])
 });
 
-export const tagsFilterAtom = filterAtom<SetFilter>({
+export const tagsFilterAtom = filterAtom<SetFilter<string>>({
     name: 'tags',
     type: 'set',
     op: 'and',
     active: true,
-    values: new Set<string>([])
+    values: new Set([])
 });
 
-export const artistFilterAtom = filterAtom<SetFilter>({
+export const artistFilterAtom = filterAtom<SetFilter<string>>({
     name: 'artist',
     type: 'set',
     op: 'or',
     active: true,
-    values: new Set<string>([])
+    values: new Set([])
 });
 
 export const bpmFilterAtom = filterAtom<RangeFilter>({

--- a/src/store/queryAndPage.ts
+++ b/src/store/queryAndPage.ts
@@ -4,7 +4,7 @@ import type { SetFilter } from './filters';
 import { artistFilterAtom, authorsFilterAtom, bpmFilterAtom, difficultyFilterAtom, tagsFilterAtom } from './filters';
 import type { WritableDraft } from 'immer/dist/internal';
 
-const clearSetFilter = (f: WritableDraft<SetFilter>) => {
+const clearSetFilter = (f: WritableDraft<SetFilter<string | number>>) => {
     f.values.clear();
 };
 

--- a/src/store/queryAndPage.ts
+++ b/src/store/queryAndPage.ts
@@ -4,7 +4,7 @@ import type { SetFilter } from './filters';
 import { artistFilterAtom, authorsFilterAtom, bpmFilterAtom, difficultyFilterAtom, tagsFilterAtom } from './filters';
 import type { WritableDraft } from 'immer/dist/internal';
 
-const clearSetFilter = (f: WritableDraft<SetFilter<string | number>>) => {
+const clearSetFilter = (f: WritableDraft<SetFilter<string>> | WritableDraft<SetFilter<number>>) => {
     f.values.clear();
 };
 


### PR DESCRIPTION
The type of a facet set used to be `Set<string | number>` but this is incorrect, because it lets you mix strings and numbers. So we were erroneously passing number strings as difficulties to typesense.

This changes the type to `<T extends string | number>Set<T>` which limits the set members to either strings or numbers but not both. 

This allows us to use backticks only for string facets, which stops it breaking number facets.